### PR TITLE
fix: Use fmt directly

### DIFF
--- a/app/nuis-hepdata.cxx
+++ b/app/nuis-hepdata.cxx
@@ -4,7 +4,7 @@
 
 #include "docopt.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 #include "spdlog/spdlog.h"
 
 #include "yaml-cpp/yaml.h"

--- a/src/nuis/HEPData/CrossSectionMeasurement.cxx
+++ b/src/nuis/HEPData/CrossSectionMeasurement.cxx
@@ -1,6 +1,6 @@
 #include "nuis/HEPData/CrossSectionMeasurement.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 namespace nuis::HEPData {
 

--- a/src/nuis/HEPData/ReferenceResolver.cxx
+++ b/src/nuis/HEPData/ReferenceResolver.cxx
@@ -4,7 +4,7 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 

--- a/src/nuis/HEPData/ResourceReference.cxx
+++ b/src/nuis/HEPData/ResourceReference.cxx
@@ -1,6 +1,6 @@
 #include "nuis/HEPData/ResourceReference.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 

--- a/src/nuis/HEPData/StreamHelpers.cxx
+++ b/src/nuis/HEPData/StreamHelpers.cxx
@@ -1,6 +1,6 @@
 #include "nuis/HEPData/StreamHelpers.h"
 
-#include "spdlog/fmt/bundled/core.h"
+#include "fmt/core.h"
 
 #include <iostream>
 

--- a/src/nuis/HEPData/TableFactory.cxx
+++ b/src/nuis/HEPData/TableFactory.cxx
@@ -5,8 +5,8 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "spdlog/fmt/bundled/core.h"
-#include "spdlog/fmt/bundled/ranges.h"
+#include "fmt/core.h"
+#include "fmt/ranges.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/spdlog.h"
 


### PR DESCRIPTION
Using the bundled fmt headers causes issues if fmt is installed externally from spdlog. Switching to using fmt directly does not mess up the other direction
